### PR TITLE
fix(documentation-website): overflow-x hidden for code snippets

### DIFF
--- a/src/components/code.scss
+++ b/src/components/code.scss
@@ -1,6 +1,6 @@
 .hljs {
   background: var(--background-offset);
-  overflow-x: scroll;
+  overflow-x: hidden;
   padding: 0.5em;
 
   > code {


### PR DESCRIPTION
# The Pull Request is ready

## Setting the `overflow-x` for code snippets to `hidden`

- [x] fixes idrinth-api-bench/issues#1092
- [x] all actions are passing
- [x] only fixes a single issue

## Overview

- I've set the `overflow-x` to `hidden` in `code.scss`
- previously it was set to `scroll`
- I verified that it appears ok on mobile too

## Review points

- I had a minor error when I tried to run it locally 

```
file:///workspaces/documentation-website/tools/load-contributors.js:128
      for (const contributor of await contributors.json()) {
                                ^

TypeError: (intermediate value) is not iterable
    at file:///workspaces/documentation-website/tools/load-contributors.js:128:33
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

```
I didn't get into it since it's out of the scope of what I was adjusting

## Documentation-Website

- [x] mobile view is usable
- [x] desktop view is usable
- [x] no a-tags are used directly (NavLink, MailLink, ExternalLink instead)
- [x] all new texts are added to the translation files (at least the english one)
- [x] tests have been added (if required)
- [x] shared code has been extracted in a different file


