### PR TITLE
fixed typo for the  `Contributing` instead of `contributors`

### DIFF
--- a/src/components/main-navigation.tsx
+++ b/src/components/main-navigation.tsx
@@ -13,7 +13,7 @@ const MainNavigation = () => <nav aria-label='Main Menu'>
     >/quick-start</MainNavigationLink>
     <MainNavigationLinks
       ariakey={'contributing'}
-      lnkey={'nav.contributors'}
+      lnkey={'nav.contributing'}
       items={[
         'contributors',
         'sponsors',


### PR DESCRIPTION
# The Pull Request is ready

- [x] fixes #1106
- [x] all actions are passing
- [x] only fixes a single issue

## Overview

There was a typo for the lnkey linked to `contributors` instead of `contributing`. 

## Review points

<!-- List the points to be reviewed in detail 
and the points you are not confident about. -->
<!-- Delete this section if not needed -->

## Documentation-Website

- [ ] mobile view is usable
- [x] desktop view is usable
- [ ] no a-tags are used directly (NavLink, MailLink, ExternalLink instead)
- [ ] all new texts are added to the translation files (at least the english one)
- [ ] tests have been added (if required)
- [ ] shared code has been extracted in a different file
- [ ] new texts are easy to read

## Notes


